### PR TITLE
Node 12 / Dependencies Update

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/erbium

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
  * Module dependencies
  */
 
+var basicAuth = require('express-basic-auth');
+var bodyParser = require('body-parser');
 var co = require('co');
 var fs = require('fs');
 var ms = require('ms');
@@ -14,6 +16,7 @@ var semver = require('semver');
 var express = require('express');
 var thunkify = require('thunkify');
 var exec = require('child_process').exec;
+var serveIndex = require('serve-index');
 
 /**
  * Config
@@ -193,9 +196,9 @@ function matchUpdate(info) {
  * Middleware
  */
 
-app.use(express.bodyParser());
+app.use(bodyParser());
 
-var auth = express.basicAuth(config.username, config.password);
+var auth = basicAuth(config.username, config.password);
 
 /**
  * Normalizes a `req.params` or `req.query` object with the proper default values.
@@ -260,7 +263,7 @@ app.get('/update', function(req, res, next) {
   if (update) {
     res.download(update.path, path.basename(update.path));
   } else {
-    res.send(404, "No updates.");
+    res.status(404).send("No updates.");
   }
 });
 
@@ -313,14 +316,14 @@ app.post('/reload', auth, function(req, res, next) {
  */
 
 app.get('/', function(req, res, next) {
-  res.send(200);
+  res.sendStatus(200);
 });
 
 /**
  * Static route to get updates
  */
 
-app.use('/static', express.directory(config.directory, { icons: true }));
+app.use('/static', serveIndex(config.directory, { icons: true }));
 app.use('/static', express.static(config.directory));
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,13 +9,16 @@
     "url": "git://github.com/Automattic/auto-update-server"
   },
   "dependencies": {
+    "body-parser": "1.19.0",
     "co": "~2.2.0",
     "co-wait": "0.0.0",
     "dive": "~0.3.0",
-    "express": "~3.0.0",
+    "express": "^4.17.1",
+    "express-basic-auth": "1.2.0",
     "gnode": "0.1.2",
     "ms": "0.7.1",
     "semver": "5.x",
+    "serve-index": "1.9.1",
     "thunkify": "0.0.1"
   },
   "bin": {


### PR DESCRIPTION
Not too many changes needed here, but there were some vulnerabilities in the `express` version we were using. The main changes needed were to add some express middlewares in that were removed from express somewhere along the way.

**To Test**
* `npm install`
* `node auto-update-server`
* Open `localhost:3000`, and try a request like `http://localhost:3000/update?app=MyApp&os=osx` (Should say `No updates.`)